### PR TITLE
Fix broken sync savedsearch

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -13,7 +13,7 @@ search = `wsus-index` sourcetype="wsus:synchronizationreport" \
 | eval s = strptime(StartTime, "%m/%d/%Y %I:%M:%S %p") \
 | eval e = strptime(EndTime, "%m/%d/%Y %I:%M:%S %p") \
 | eval Duration = tostring(e - s) \
-| eval Duration = round(Duration, 2) \ 
+| eval Duration = round(Duration, 2) \
 | eval Duration = tostring(Duration, "Duration") \
 | eval SynchronizationType = if(StartedManually == "True", "Manual", "Scheduled") \
 | table StartTime, EndTime, Duration, Result, SynchronizationType


### PR DESCRIPTION
Sync reports are broken because of a trailing space.